### PR TITLE
fix(hero): add overflow-hidden to resolve layout overflow issue (#41)

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 export default function Hero() {
   return (
-    <section className="relative mt-16 md:mt-0 mx-auto grid min-h-[70vh] w-full max-w-6xl grid-cols-1 items-center gap-8 px-4 py-8 md:min-h-[80vh] md:grid-cols-2 md:px-8 lg:px-16">
+    <section className="relative mt-16 md:mt-0 mx-auto grid min-h-[70vh] w-full max-w-6xl grid-cols-1 items-center gap-8 px-4 py-8 md:min-h-[80vh] md:grid-cols-2 md:px-8 lg:px-16 overflow-hidden">
       <div className="order-1 z-100 md:order-1">
         <h1 className="text-left text-5xl font-normal leading-tight text-black md:text-6xl lg:text-7xl" style={{ fontFamily: 'Instrument Serif, var(--font-instrument-serif), serif' }}>
           All your kadi <span className='font-bold italic text-[#03b051]'>jokes</span> in one place


### PR DESCRIPTION
Fixes #41

### Summary
This PR adds `overflow-hidden` to the Hero section container to prevent the hero
image from overflowing its bounding box. The issue caused layout shifting
and unwanted scrollbars on some devices.

### Changes Made
- Updated `components/hero.js`
- Added `overflow-hidden` to the main <section> element
- Ensures clean layout and prevents accidental horizontal scrolling

### Before / After
- Before: Hero image overflowed outside the container on certain viewports.
- After: Layout is stable and contained within expected boundaries.

Please review and merge.
